### PR TITLE
Merge archon-skills content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Archon Skills
+
+Agent skills for [Archon](https://archon.technology) — decentralized identity infrastructure.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| [archon-nostr](./archon-nostr/) | Derive Nostr identity (npub/nsec) from Archon DID |
+
+## Installation
+
+Skills can be installed via [ClawhHub](https://clawhub.com) or manually copied to your agent's skills directory.
+
+## Contributing
+
+PRs welcome. Skills should follow the [OpenClaw skill format](https://docs.openclaw.ai).
+
+---
+
+*Maintained by [Morningstar](https://morningstar-daemon.github.io)*

--- a/archon-nostr/SKILL.md
+++ b/archon-nostr/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: archon-nostr
+description: Derive Nostr identity (npub/nsec) from Archon DID. Use when unifying DID and Nostr identities so both use the same secp256k1 key. Requires existing Archon wallet with ARCHON_PASSPHRASE set.
+---
+
+# Archon Nostr Identity
+
+Derive your Nostr keypair from your Archon DID's secp256k1 verification key. Same key, two protocols.
+
+## Prerequisites
+
+- Archon wallet with existing DID
+- `ARCHON_PASSPHRASE` environment variable set
+- `nak` CLI: `curl -sSL https://raw.githubusercontent.com/fiatjaf/nak/master/install.sh | sh`
+
+## Derive Keys
+
+Run the derivation script:
+
+```bash
+./scripts/derive-nostr.sh
+```
+
+This outputs your `nsec`, `npub`, and hex pubkey derived from `m/44'/0'/0'/0/0`.
+
+## Save Keys
+
+```bash
+mkdir -p ~/.clawstr
+# Save the nsec output from above
+echo "nsec1..." > ~/.clawstr/secret.key
+chmod 600 ~/.clawstr/secret.key
+```
+
+## Update DID Document
+
+Add Nostr identity for discoverability:
+
+```bash
+npx @didcid/keymaster set-property YourIdName nostr \
+  '{"npub":"npub1...","pubkey":"<hex-pubkey>"}'
+```
+
+## Create Nostr Profile
+
+```bash
+echo '{
+  "kind": 0,
+  "content": "{\"name\":\"YourName\",\"about\":\"Your bio. DID: did:cid:...\"}"
+}' | nak event --sec $(cat ~/.clawstr/secret.key) \
+  wss://relay.ditto.pub wss://relay.primal.net wss://relay.damus.io wss://nos.lol
+```
+
+## Verify Unification
+
+The DID's JWK `x` coordinate (base64url) decodes to the same hex as your Nostr pubkey:
+
+```bash
+npx @didcid/keymaster resolve-id | jq -r '.didDocument.verificationMethod[0].publicKeyJwk.x'
+# Decode base64url → hex should match your pubkey
+```
+
+## Why This Works
+
+Archon uses `m/44'/0'/0'/0/0` (Bitcoin BIP44 path) for DID keys. Nostr uses raw secp256k1. Same curve, same key — just different encodings.

--- a/archon-nostr/scripts/derive-nostr.sh
+++ b/archon-nostr/scripts/derive-nostr.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Derive Nostr keys from Archon DID mnemonic
+# Requires: node, npx @didcid/keymaster
+
+set -e
+
+DEPS_DIR="/tmp/archon-nostr-deps"
+
+# Get mnemonic from keymaster
+MNEMONIC=$(npx @didcid/keymaster show-mnemonic 2>/dev/null)
+
+if [ -z "$MNEMONIC" ]; then
+  echo "Error: Could not get mnemonic. Is ARCHON_PASSPHRASE set?" >&2
+  exit 1
+fi
+
+# Install dependencies if needed
+if [ ! -f "$DEPS_DIR/node_modules/bip39/package.json" ]; then
+  echo "Installing dependencies..." >&2
+  mkdir -p "$DEPS_DIR"
+  cd "$DEPS_DIR"
+  npm install --silent bip39 @scure/bip32 secp256k1 bech32 >/dev/null 2>&1
+  cd - >/dev/null
+fi
+
+# Run derivation
+cd "$DEPS_DIR"
+node --input-type=commonjs <<EOF
+const bip39 = require('bip39');
+const { HDKey } = require('@scure/bip32');
+const secp256k1 = require('secp256k1');
+const { bech32 } = require('bech32');
+
+const mnemonic = '${MNEMONIC}';
+const seed = bip39.mnemonicToSeedSync(mnemonic);
+const hdkey = HDKey.fromMasterSeed(seed);
+
+// Archon uses Bitcoin BIP44 path
+const derived = hdkey.derive("m/44'/0'/0'/0/0");
+const privKey = derived.privateKey;
+const pubKey = secp256k1.publicKeyCreate(privKey, false);
+const pubKeyX = Buffer.from(pubKey.slice(1, 33)).toString('hex');
+
+function toBech32(prefix, hex) {
+  const bytes = Buffer.from(hex, 'hex');
+  const words = bech32.toWords(bytes);
+  return bech32.encode(prefix, words, 1000);
+}
+
+const nsec = toBech32('nsec', Buffer.from(privKey).toString('hex'));
+const npub = toBech32('npub', pubKeyX);
+
+console.log('nsec:', nsec);
+console.log('npub:', npub);
+console.log('pubkey:', pubKeyX);
+EOF


### PR DESCRIPTION
This PR merges all content from morningstar-daemon/archon-skills into archetech/agent-skills.

**Contents:**
- `archon-nostr/` skill - Derive Nostr identity (npub/nsec) from Archon DID
- Uses same secp256k1 key as DID for unified identity

After merge, archetech/agent-skills will be identical to archon-skills.