### PR TITLE
Add archon-names skill - universal DID naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Agent skills for [Archon](https://archon.technology) — decentralized identity 
 | Skill | Description |
 |-------|-------------|
 | [archon-id](./archon-id/) | **Start here** - Create and manage Archon DIDs, multi-identity support |
+| [archon-names](./archon-names/) | Assign friendly names to DIDs (contacts, schemas, vaults) |
 | [archon-backup](./archon-backup/) | Automated secure backups of workspace, config, and memory to Archon DID vault |
 | [archon-nostr](./archon-nostr/) | Derive Nostr identity (npub/nsec) from Archon DID |
 

--- a/archon-names/SKILL.md
+++ b/archon-names/SKILL.md
@@ -1,0 +1,185 @@
+# Archon Names - DID Naming and Resolution
+
+Manage friendly names for DIDs. Use names instead of full DIDs for agents, schemas, vaults, and more.
+
+## What This Skill Does
+
+Provides a simple naming system for Archon DIDs:
+- **Add names** - Assign friendly names to any DID
+- **Resolve names** - Look up DIDs by name
+- **List names** - View all your named DIDs
+- **Remove names** - Delete name mappings
+
+Names work everywhere - most Keymaster commands accept names OR DIDs.
+
+## Prerequisites
+
+- Archon identity set up (run [archon-id](../archon-id/) skill first)
+- `~/.archon.env` configured
+
+## Use Cases
+
+**Agent/Person Contacts:**
+```bash
+./add-name.sh alice did:cid:bagaaiera...
+./add-name.sh bob did:cid:bagaaierc...
+./add-name.sh cypher did:cid:bagaaierd...
+```
+
+**Schema DIDs:**
+```bash
+./add-name.sh proof-of-human did:cid:bagaaiera4yl4xi...
+./add-name.sh proof-of-ai did:cid:bagaaieratedl6c...
+./add-name.sh certification-schema did:cid:bagaaierabc123...
+```
+
+**Vault DIDs:**
+```bash
+./add-name.sh backup did:cid:bagaaierab...
+./add-name.sh shared-workspace did:cid:bagaaierac...
+```
+
+**Organization:**
+- Use consistent naming patterns (e.g., `-schema` suffix for schemas)
+- Group related DIDs with prefixes (e.g., `work-alice`, `work-bob`)
+- Keep names descriptive but concise
+
+## Usage
+
+### Add a Name
+
+```bash
+./add-name.sh <name> <did>
+```
+
+Example:
+```bash
+./add-name.sh alice did:cid:bagaaiera123...
+```
+
+Once added, you can use "alice" anywhere that accepts a DID.
+
+### Resolve a Name to DID
+
+```bash
+./resolve-did.sh <name-or-did>
+```
+
+Examples:
+```bash
+./resolve-did.sh alice
+# Returns: did:cid:bagaaiera123...
+
+./resolve-did.sh did:cid:bagaaiera123...
+# Returns: did:cid:bagaaiera123... (pass-through)
+```
+
+**Note:** `resolve-did` accepts both names and DIDs. If you pass a DID, it returns the DID unchanged. This makes it safe to use in scripts without checking if input is a name or DID.
+
+### List All Names
+
+```bash
+./list-names.sh
+```
+
+Shows all name → DID mappings in your wallet.
+
+### Remove a Name
+
+```bash
+./remove-name.sh <name>
+```
+
+Example:
+```bash
+./remove-name.sh alice
+```
+
+Removes the name mapping. The DID itself is not affected, just the name.
+
+## Integration with Other Skills
+
+### Using Names in Keymaster Commands
+
+Most Keymaster commands accept names OR DIDs:
+
+```bash
+# Issue credential to named contact
+npx @didcid/keymaster issue-credential \
+  --to alice \
+  --schema proof-of-human \
+  --claims '{"verified": true}'
+
+# Add item to named vault
+npx @didcid/keymaster add-vault-item backup file.txt
+
+# Verify signature from named DID
+npx @didcid/keymaster verify-signature \
+  --did bob \
+  --message "hello" \
+  --signature <sig>
+```
+
+### Examples in Scripts
+
+```bash
+#!/bin/bash
+# Send message to contact by name
+
+RECIPIENT="$1"
+MESSAGE="$2"
+
+# Resolve name to DID (works with names or DIDs)
+RECIPIENT_DID=$(./resolve-did.sh "$RECIPIENT")
+
+# Use the DID
+send-encrypted-message "$RECIPIENT_DID" "$MESSAGE"
+```
+
+## Name Organization Patterns
+
+**By Purpose:**
+- Contacts: `alice`, `bob`, `cypher`
+- Schemas: `proof-of-human-schema`, `certification-schema`
+- Vaults: `backup-vault`, `shared-vault`
+
+**By Context:**
+- Work: `work-alice`, `work-shared-vault`
+- Personal: `personal-bob`, `personal-backup`
+- Public: `public-schema`, `public-profile`
+
+**By Trust Level:**
+- Verified: `verified-alice`, `verified-schema`
+- Pending: `pending-bob`, `unverified-schema`
+
+## Storage
+
+Names are stored in your Archon wallet (`~/clawd/wallet.json`), encrypted with your passphrase. No separate files needed.
+
+**Backup:** Names are automatically included when you backup your wallet (via archon-backup skill or seed bank).
+
+## Security Notes
+
+- Names are local to your wallet (other agents don't see your naming)
+- Removing a name doesn't affect the underlying DID
+- Names are included in wallet backups
+- No centralized name registry (fully decentralized)
+
+## Troubleshooting
+
+**"Name not found":**
+- Check spelling: `./list-names.sh`
+- Ensure name was added: `./add-name.sh <name> <did>`
+
+**"Permission denied":**
+- Ensure `.archon.env` is loaded: `source ~/.archon.env`
+- Check passphrase is correct
+
+**Naming conflicts:**
+- Each name must be unique in your wallet
+- Removing old name before adding new one: `./remove-name.sh old-name`
+
+## References
+
+- Keymaster documentation: https://github.com/archetech/archon/tree/main/keymaster
+- DID specification: https://www.w3.org/TR/did-core/

--- a/archon-names/scripts/add-name.sh
+++ b/archon-names/scripts/add-name.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Add a friendly name for a DID
+# Usage: ./add-name.sh <name> <did>
+
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <name> <did>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 alice did:cid:bagaaiera..."
+    echo "  $0 proof-of-human-schema did:cid:bagaaiera4yl4xi..."
+    echo "  $0 backup-vault did:cid:bagaaierab..."
+    exit 1
+fi
+
+NAME="$1"
+DID="$2"
+
+# Load environment
+if [ -f ~/.archon.env ]; then
+    source ~/.archon.env
+else
+    echo "ERROR: ~/.archon.env not found"
+    echo "Run archon-id skill first to set up your environment"
+    exit 1
+fi
+
+# Add name
+cd ~/clawd
+npx @didcid/keymaster add-name "$NAME" "$DID"
+
+echo ""
+echo "✓ Name '$NAME' added for DID: $DID"
+echo ""
+echo "You can now use '$NAME' in place of the full DID in Keymaster commands."

--- a/archon-names/scripts/list-names.sh
+++ b/archon-names/scripts/list-names.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# List all name → DID mappings
+
+set -e
+
+# Load environment
+if [ -f ~/.archon.env ]; then
+    source ~/.archon.env
+else
+    echo "ERROR: ~/.archon.env not found"
+    exit 1
+fi
+
+echo "=== Your Named DIDs ==="
+echo ""
+
+cd ~/clawd
+npx @didcid/keymaster list-names
+
+echo ""
+echo "Add name: ./add-name.sh <name> <did>"
+echo "Remove name: ./remove-name.sh <name>"
+echo "Resolve: ./resolve-did.sh <name>"

--- a/archon-names/scripts/remove-name.sh
+++ b/archon-names/scripts/remove-name.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Remove a name mapping
+# Usage: ./remove-name.sh <name>
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <name>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 alice"
+    echo "  $0 old-schema"
+    exit 1
+fi
+
+NAME="$1"
+
+# Load environment
+if [ -f ~/.archon.env ]; then
+    source ~/.archon.env
+else
+    echo "ERROR: ~/.archon.env not found"
+    exit 1
+fi
+
+# Remove name
+cd ~/clawd
+npx @didcid/keymaster remove-name "$NAME"
+
+echo ""
+echo "✓ Name '$NAME' removed"

--- a/archon-names/scripts/resolve-did.sh
+++ b/archon-names/scripts/resolve-did.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Resolve a name to its DID (or pass through a DID unchanged)
+# Usage: ./resolve-did.sh <name-or-did>
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <name-or-did>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 alice"
+    echo "  $0 did:cid:bagaaiera..."
+    exit 1
+fi
+
+NAME_OR_DID="$1"
+
+# Load environment
+if [ -f ~/.archon.env ]; then
+    source ~/.archon.env
+else
+    echo "ERROR: ~/.archon.env not found"
+    exit 1
+fi
+
+# Resolve (works with both names and DIDs)
+cd ~/clawd
+npx @didcid/keymaster resolve-did "$NAME_OR_DID"


### PR DESCRIPTION
Universal naming system for all Archon DIDs.

## What It Does

Provides friendly names for DIDs instead of remembering full `did:cid:...` strings:

**Contacts:**
```bash
./add-name.sh alice did:cid:bagaaiera...
./add-name.sh bob did:cid:bagaaierc...
```

**Schemas:**
```bash
./add-name.sh proof-of-human did:cid:bagaaiera4yl4xi...
./add-name.sh certification-schema did:cid:bagaaierabc...
```

**Vaults:**
```bash
./add-name.sh backup did:cid:bagaaierab...
./add-name.sh shared-workspace did:cid:bagaaierac...
```

## How It Works

**Storage:** Names stored in your Archon wallet (`~/clawd/wallet.json`), encrypted with passphrase. No separate files.

**Resolution:** Most Keymaster commands accept names OR DIDs:
```bash
npx @didcid/keymaster issue-credential --to alice --schema proof-of-human
npx @didcid/keymaster add-vault-item backup file.txt
npx @didcid/keymaster verify-signature --did bob ...
```

## Scripts

- `add-name.sh <name> <did>` - Assign friendly name
- `remove-name.sh <name>` - Remove name mapping
- `resolve-did.sh <name-or-did>` - Lookup DID (or pass through DID unchanged)
- `list-names.sh` - Show all named DIDs

## Integration

Builds on archon-id foundation. Makes other skills easier to use:
- Issue credentials to "alice" instead of full DID
- Reference schemas by name: "proof-of-human-schema"
- Access vaults by name: "backup", "shared-workspace"

## Why Universal Names

Agents use the same naming mechanism for:
- People/agent contacts
- Schema DIDs (for credentials)
- Vault DIDs (for storage)
- Any DID that needs a memorable reference

One simple system for everything.