### PR TITLE
Fix: Default to public gatekeeper (archon.technology)

### DIFF
--- a/archon-backup/SKILL.md
+++ b/archon-backup/SKILL.md
@@ -26,10 +26,16 @@ Your backups are:
 
 ### Gatekeeper Options
 
-- **Public** (`https://archon.technology`) - 10MB file size limit, suitable for most agents
-- **Local** (`http://localhost:4224`) - Unlimited size, for large archives (>10MB)
+Skills default to the **public gatekeeper** (`https://archon.technology`):
+- **Pros:** No local setup required, works immediately
+- **Cons:** 10MB file size limit per item
 
-If your backups exceed 10MB, run a local Archon node (docs coming soon).
+For backups larger than 10MB, run a **local Archon node**:
+1. Install Archon locally: https://github.com/archetech/archon
+2. Update `~/.archon.env`:
+   ```bash
+   export ARCHON_GATEKEEPER_URL="http://localhost:4224"  # Unlimited size
+   ```
 
 ## Setup
 

--- a/archon-backup/scripts/backup-to-vault.sh
+++ b/archon-backup/scripts/backup-to-vault.sh
@@ -13,8 +13,9 @@ else
     exit 1
 fi
 
-# Use local Gatekeeper (unlimited size)
-export ARCHON_GATEKEEPER_URL="http://localhost:4224"
+# Use public Gatekeeper by default (10MB limit)
+# Override with local if needed: export ARCHON_GATEKEEPER_URL="http://localhost:4224"
+export ARCHON_GATEKEEPER_URL="${ARCHON_GATEKEEPER_URL:-https://archon.technology}"
 
 # Ensure Keymaster always uses the correct wallet regardless of cwd
 export KEYMASTER_WALLET="$HOME/clawd/wallet.json"

--- a/archon-backup/scripts/verify-backup.sh
+++ b/archon-backup/scripts/verify-backup.sh
@@ -13,8 +13,9 @@ else
     exit 1
 fi
 
-# Use local Gatekeeper (unlimited size)
-export ARCHON_GATEKEEPER_URL="http://localhost:4224"
+# Use public Gatekeeper by default (10MB limit)
+# Override with local if needed: export ARCHON_GATEKEEPER_URL="http://localhost:4224"
+export ARCHON_GATEKEEPER_URL="${ARCHON_GATEKEEPER_URL:-https://archon.technology}"
 
 # Ensure Keymaster uses correct wallet
 export KEYMASTER_WALLET="$HOME/clawd/wallet.json"

--- a/archon-id/SKILL.md
+++ b/archon-id/SKILL.md
@@ -12,7 +12,9 @@ Manages your Archon decentralized identities (DIDs):
 ## Prerequisites
 
 - Node.js installed (for `npx @didcid/keymaster`)
-- Archon Gatekeeper access (public: `https://archon.technology` or local: `http://localhost:4224`)
+- Internet connection (uses public Archon gatekeeper at `https://archon.technology`)
+
+**Optional:** Run local Archon node for offline operations or custom configuration
 
 ## Initial Setup
 

--- a/archon-id/scripts/create-id.sh
+++ b/archon-id/scripts/create-id.sh
@@ -39,7 +39,8 @@ cat > ~/.archon.env << EOF
 # Archon passphrase - keeps your wallet encrypted
 # DO NOT COMMIT THIS FILE TO GIT
 export ARCHON_PASSPHRASE="$PASSPHRASE"
-export ARCHON_GATEKEEPER_URL="http://localhost:4224"  # or https://archon.technology
+export ARCHON_GATEKEEPER_URL="https://archon.technology"  # Public gatekeeper (10MB limit)
+# For local gatekeeper (unlimited): export ARCHON_GATEKEEPER_URL="http://localhost:4224"
 export KEYMASTER_WALLET="$HOME/clawd/wallet.json"
 EOF
 


### PR DESCRIPTION
Changes skills to use public gatekeeper by default instead of assuming local Archon node.

## Problem

Current skills assume users run a local Archon node (`http://localhost:4224`), but most agents won't. The public gatekeeper at `https://archon.technology` should be the default.

## Changes

**archon-id:**
- `.archon.env` created with `ARCHON_GATEKEEPER_URL="https://archon.technology"`
- Comment shows how to switch to local
- Documentation updated: public is standard, local is optional

**archon-backup:**
- Scripts use `${ARCHON_GATEKEEPER_URL:-https://archon.technology}` (respects env var if set)
- Clear documentation on public vs local tradeoffs
- Instructions for switching to local when needed

## Public vs Local Tradeoffs

**Public Gatekeeper (`https://archon.technology`):**
- ✓ Works immediately (no setup)
- ✓ Suitable for most agents
- ✗ 10MB file size limit

**Local Gatekeeper (`http://localhost:4224`):**
- ✓ Unlimited file size
- ✓ Offline operations
- ✗ Requires Docker setup

## Migration

Existing users with local nodes already have `ARCHON_GATEKEEPER_URL` set in their `.archon.env`, so this won't affect them. New users get the public gatekeeper by default.

Fixes #12