### PR TITLE
Update Recovery section with automated disaster recovery

### DIFF
--- a/archon/SKILL.md
+++ b/archon/SKILL.md
@@ -66,19 +66,19 @@ Create pseudonymous personas or role-separated identities (all share same mnemon
 
 ### Recovery
 
-**Complete disaster recovery (automated):**
+**Complete disaster recovery:**
 ```bash
 ./scripts/backup/disaster-recovery.sh "word1 word2 ... word12" [target-dir]
 ```
 
-Single command recovery from just your 12-word mnemonic. Imports wallet, recovers from seed bank, and restores all backups from vault.
+Recovers everything from just your 12-word mnemonic.
 
-**Manual recovery (step-by-step):**
+**Restore from existing wallet:**
 ```bash
-npx @didcid/keymaster import-wallet "word1 word2 ... word12"
-npx @didcid/keymaster recover-wallet-did
-./scripts/backup/restore-from-vault.sh
+./scripts/backup/restore-from-vault.sh [target-dir]
 ```
+
+If you already have your wallet, use this to restore workspace/config/memory from vault backups.
 
 ## Encrypted Messaging (Dmail)
 


### PR DESCRIPTION
Updates the Recovery section in the unified archon skill to show the new automated disaster recovery script as the primary method.

## Changes

- Shows `disaster-recovery.sh` as the recommended recovery method (one command)
- Keeps manual step-by-step commands as a fallback option
- Adds `restore-from-vault.sh` to manual recovery steps

## Before

```bash
npx @didcid/keymaster import-wallet "word1 word2 ... word12"
npx @didcid/keymaster recover-wallet-did
```

## After

Primary method (automated):
```bash
./scripts/backup/disaster-recovery.sh "word1 word2 ... word12" [target-dir]
```

Manual fallback:
```bash
npx @didcid/keymaster import-wallet "word1 word2 ... word12"
npx @didcid/keymaster recover-wallet-did
./scripts/backup/restore-from-vault.sh
```