### PR TITLE
Add vault management to archon-keymaster

### DIFF
--- a/archon-keymaster/scripts/vaults/add-vault-item.sh
+++ b/archon-keymaster/scripts/vaults/add-vault-item.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Add an item (file) to a vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <vault-id> <file-path>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+FILE_PATH="$2"
+
+if [ ! -f "$FILE_PATH" ]; then
+    echo "Error: File not found: $FILE_PATH"
+    exit 1
+fi
+
+# Add item to vault
+npx @didcid/keymaster add-vault-item "$VAULT_ID" "$FILE_PATH"

--- a/archon-keymaster/scripts/vaults/add-vault-member.sh
+++ b/archon-keymaster/scripts/vaults/add-vault-member.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Add a member to a vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <vault-id> <member-did>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+MEMBER_DID="$2"
+
+# Add member to vault
+npx @didcid/keymaster add-vault-member "$VAULT_ID" "$MEMBER_DID"

--- a/archon-keymaster/scripts/vaults/create-vault.sh
+++ b/archon-keymaster/scripts/vaults/create-vault.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Create a new vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Parse arguments
+VAULT_ALIAS=""
+SECRET_MEMBERS=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -a|--alias)
+            VAULT_ALIAS="$2"
+            shift 2
+            ;;
+        -s|--secret-members)
+            SECRET_MEMBERS="--secretMembers"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [-a|--alias <vault-alias>] [-s|--secret-members]"
+            exit 1
+            ;;
+    esac
+done
+
+# Create vault
+if [ -n "$VAULT_ALIAS" ]; then
+    npx @didcid/keymaster create-vault --alias "$VAULT_ALIAS" $SECRET_MEMBERS
+else
+    npx @didcid/keymaster create-vault $SECRET_MEMBERS
+fi

--- a/archon-keymaster/scripts/vaults/get-vault-item.sh
+++ b/archon-keymaster/scripts/vaults/get-vault-item.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Get an item from a vault and save to file
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <vault-id> <item-name> <output-file>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+ITEM_NAME="$2"
+OUTPUT_FILE="$3"
+
+# Get item from vault
+npx @didcid/keymaster get-vault-item "$VAULT_ID" "$ITEM_NAME" "$OUTPUT_FILE"

--- a/archon-keymaster/scripts/vaults/list-vault-items.sh
+++ b/archon-keymaster/scripts/vaults/list-vault-items.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# List all items in a vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <vault-id>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+
+# List items in vault
+npx @didcid/keymaster list-vault-items "$VAULT_ID"

--- a/archon-keymaster/scripts/vaults/list-vault-members.sh
+++ b/archon-keymaster/scripts/vaults/list-vault-members.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# List all members of a vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <vault-id>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+
+# List vault members
+npx @didcid/keymaster list-vault-members "$VAULT_ID"

--- a/archon-keymaster/scripts/vaults/remove-vault-item.sh
+++ b/archon-keymaster/scripts/vaults/remove-vault-item.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Remove an item from a vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <vault-id> <item-name>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+ITEM_NAME="$2"
+
+# Remove item from vault
+npx @didcid/keymaster remove-vault-item "$VAULT_ID" "$ITEM_NAME"

--- a/archon-keymaster/scripts/vaults/remove-vault-member.sh
+++ b/archon-keymaster/scripts/vaults/remove-vault-member.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Remove a member from a vault
+
+set -e
+
+# Ensure environment is loaded
+if [ -z "$ARCHON_PASSPHRASE" ]; then
+    if [ -f ~/.archon.env ]; then
+        source ~/.archon.env
+    else
+        echo "Error: ARCHON_PASSPHRASE not set. Run create-id.sh first."
+        exit 1
+    fi
+fi
+
+# Set wallet path
+export ARCHON_WALLET_PATH="${ARCHON_WALLET_PATH:-$HOME/clawd/wallet.json}"
+
+# Check arguments
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <vault-id> <member-did>"
+    exit 1
+fi
+
+VAULT_ID="$1"
+MEMBER_DID="$2"
+
+# Remove member from vault
+npx @didcid/keymaster remove-vault-member "$VAULT_ID" "$MEMBER_DID"


### PR DESCRIPTION
Closes #14

**Summary:**
Adds complete vault management functionality to the archon-keymaster skill.

**Changes:**
- Created 8 vault operation scripts in `scripts/vaults/`:
  - `create-vault.sh` - Create vaults with optional alias and secret-members flag
  - `add-vault-item.sh` - Add files to vaults
  - `get-vault-item.sh` - Retrieve items from vaults
  - `remove-vault-item.sh` - Remove items from vaults
  - `list-vault-items.sh` - List all items with metadata
  - `add-vault-member.sh` - Add member DIDs to vaults
  - `remove-vault-member.sh` - Remove member access
  - `list-vault-members.sh` - List vault members

- Updated `SKILL.md`:
  - Added complete 'Vault Management' section with documentation and examples
  - Updated skill description to include vault management
  - Added vault management to capabilities list
  - Documented multi-party vault sharing workflow

**Testing:**
All scripts tested successfully:
- Created test vault with alias
- Added/retrieved/removed vault items
- Added/listed/removed vault members
- Verified all operations return expected output

**Pattern:**
Follows same organization as `credentials/` and `schemas/` script directories. All scripts use standard Archon environment variables and passphrase handling.