### PR TITLE
Add archon-lightning skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Agent skills for [Archon](https://archon.technology) — decentralized identity 
 | [archon-keymaster](./archon-keymaster/) | Core DID toolkit — identity management, verifiable credentials, encrypted messaging (dmail), Nostr integration, file encryption/signing, authorization, groups, and polls |
 | [archon-vault](./archon-vault/) | Encrypted distributed storage — vault management, multi-party access, workspace/config backups, disaster recovery |
 | [archon-cashu](./archon-cashu/) | DID-integrated ecash — Cashu tokens locked to DIDs (P2PK), LNBITS integration |
+| [archon-lightning](./archon-lightning/) | Lightning Network payments — wallet creation, invoice generation/payment, Lightning Address zaps, payment verification, DID integration |
 
 ## Installation
 

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -1,0 +1,342 @@
+# archon-lightning
+
+> Lightning Network payments powered by Archon DIDs
+
+Send and receive Bitcoin over Lightning. No custody. No permission. Just your DID and the Lightning Network.
+
+## What is this?
+
+`archon-lightning` integrates the Lightning Network with [Archon](https://github.com/archetech/archon) decentralized identities (DIDs). Your DID becomes your Lightning identity - no separate wallet app, no custodian, no KYC.
+
+- ⚡ **Lightning wallets for DIDs** - Each DID can have its own Lightning wallet
+- 💸 **Send/receive sats** - Pay BOLT11 invoices or create invoices to receive payments
+- ⚡ **Lightning Address zaps** - Send to `user@domain.com` Lightning Addresses
+- ✅ **Payment verification** - Cryptographic proof that payments settled
+- 📊 **Payment history** - Track all Lightning transactions
+- 🔗 **DID integration** - Publish your Lightning endpoint to your DID document
+
+All powered by your Archon DID - same cryptographic identity across protocols.
+
+## Why does this matter?
+
+**The problem:** AI agents need to pay for services (APIs, compute, data). Traditional payment rails require:
+- Bank accounts (agents can't open them)
+- Credit cards (same problem)
+- Custodial services (trust someone else with your funds)
+- Complex integrations (OAuth, API keys, rate limits)
+
+**The solution:** Lightning Network provides:
+- Instant payments (sub-second settlement)
+- Micropayments (pay per API call, not monthly subscriptions)
+- Global reach (no borders, no intermediaries)
+- Privacy (no personal information required)
+- Non-custodial (your keys, your coins)
+
+Archon DIDs + Lightning = **financial autonomy for AI agents**.
+
+## Quick Examples
+
+### Create a Lightning Wallet
+
+```bash
+./scripts/lightning/add-lightning.sh
+```
+
+Your DID now has a Lightning wallet. That's it.
+
+### Check Balance
+
+```bash
+./scripts/lightning/lightning-balance.sh
+```
+
+### Receive Sats (Create Invoice)
+
+```bash
+./scripts/lightning/lightning-invoice.sh 1000 "Coffee payment"
+# Returns BOLT11 invoice: lnbc10u1...
+```
+
+Share that invoice. When paid, sats arrive in your wallet instantly.
+
+### Pay an Invoice
+
+```bash
+./scripts/lightning/lightning-pay.sh lnbc10u1...
+# Returns payment hash
+```
+
+**Critical:** Always verify payments settled!
+
+```bash
+HASH=$(./scripts/lightning/lightning-pay.sh lnbc10u1... | jq -r .paymentHash)
+./scripts/lightning/lightning-check.sh "$HASH"
+# {"paid": true} means payment confirmed
+```
+
+### Zap via Lightning Address
+
+```bash
+./scripts/lightning/lightning-zap.sh user@getalby.com 1000 "Great post!"
+```
+
+Send to Lightning Addresses, DIDs, or aliases - all in one command.
+
+### Payment History
+
+```bash
+./scripts/lightning/lightning-payments.sh
+```
+
+## What Can You Build?
+
+**AI-to-AI Payments:**
+- Agent pays another agent for API access
+- Skill marketplace with Lightning payments
+- Bounties paid in sats for completed tasks
+- Subscription services charged per-use
+
+**Content Monetization:**
+- Pay-per-article (unlock with Lightning payment)
+- Streaming sats for video/audio
+- Microtips for social media posts
+- Paywalled APIs
+
+**Decentralized Services:**
+- Pay for compute/storage in real-time
+- Lightning-gated access control
+- Atomic payments for data feeds
+- Cross-agent value transfer
+
+**Value-4-Value:**
+- Podcast boosts/streaming sats
+- Creator tips via Lightning Address
+- P2P payments without intermediaries
+
+## How It Works
+
+### Lightning Wallet Creation
+
+When you run `add-lightning`, your DID creates a Lightning wallet using your DID's cryptographic identity:
+
+```
+DID private key → Lightning node seed → Lightning wallet
+```
+
+The wallet is non-custodial - you control the keys, you control the funds.
+
+### Payment Flow
+
+**Receiving:**
+1. Create invoice (`lightning-invoice`) → BOLT11 string
+2. Share invoice (QR code, copy/paste, etc.)
+3. Payer pays → sats arrive in your wallet
+4. Check invoice status (`lightning-check`)
+
+**Sending:**
+1. Get BOLT11 invoice (from recipient)
+2. Decode (optional: `lightning-decode` to verify amount/recipient)
+3. Pay (`lightning-pay`) → returns payment hash
+4. **Verify payment settled** (`lightning-check`)
+
+### Payment Verification Pattern
+
+**⚠️ Critical Security Pattern:**
+
+A payment hash does NOT mean the payment succeeded. Lightning payments can:
+- Be pending (not yet routed)
+- Fail (no route, insufficient balance)
+- Time out (invoice expired)
+
+**Always verify with `lightning-check`:**
+
+```bash
+# ❌ WRONG - Assumes payment hash = success
+result=$(./scripts/lightning/lightning-pay.sh lnbc10u1...)
+echo "Payment sent!" # NOPE!
+
+# ✅ CORRECT - Verify payment settled
+result=$(./scripts/lightning/lightning-pay.sh lnbc10u1...)
+hash=$(echo "$result" | jq -r .paymentHash)
+status=$(./scripts/lightning/lightning-check.sh "$hash" | jq -r .paid)
+
+if [ "$status" = "true" ]; then
+  echo "✅ Payment confirmed"
+else
+  echo "❌ Payment failed or pending"
+  exit 1
+fi
+```
+
+This pattern prevents:
+- False confirmation (thinking you paid when you didn't)
+- Double payments (retrying when payment actually succeeded)
+- Lost funds (overpaying due to confusion)
+
+### Lightning Address
+
+Lightning Addresses (`user@domain.com`) are human-readable payment endpoints. They resolve to BOLT11 invoices via LNURL.
+
+```bash
+./scripts/lightning/lightning-zap.sh user@getalby.com 1000
+```
+
+Behind the scenes:
+1. Query `https://domain.com/.well-known/lnurlp/user`
+2. Get invoice endpoint
+3. Request invoice for amount
+4. Pay BOLT11 invoice
+5. Verify payment
+
+### DID Integration
+
+Publish your Lightning endpoint to your DID document so others can pay you:
+
+```bash
+./scripts/lightning/publish-lightning.sh
+```
+
+Your DID document now includes:
+```json
+{
+  "id": "did:cid:bagaaiera...",
+  "lightning": {
+    "endpoint": "https://...",
+    "address": "user@domain.com"
+  }
+}
+```
+
+Anyone can look up your DID and pay you via Lightning.
+
+## Installation
+
+```bash
+# Clone the agent-skills repo
+git clone https://github.com/archetech/agent-skills
+cd agent-skills/archon-lightning
+
+# Prerequisites: Archon identity configured
+# (If not, see archon-keymaster first)
+
+# Create Lightning wallet
+./scripts/lightning/add-lightning.sh
+
+# Verify it worked
+./scripts/lightning/lightning-balance.sh
+# {"balance": 0}
+```
+
+See [SKILL.md](./SKILL.md) for complete documentation.
+
+## Architecture
+
+```
+archon-lightning/
+├── scripts/
+│   └── lightning/
+│       ├── add-lightning.sh           # Create wallet
+│       ├── lightning-balance.sh       # Check balance
+│       ├── lightning-invoice.sh       # Create invoice
+│       ├── lightning-pay.sh           # Pay invoice
+│       ├── lightning-check.sh         # Verify payment
+│       ├── lightning-zap.sh           # Lightning Address payment
+│       ├── lightning-payments.sh      # Payment history
+│       ├── publish-lightning.sh       # Publish to DID
+│       ├── unpublish-lightning.sh     # Remove from DID
+│       └── lightning-decode.sh        # Decode invoice
+├── README.md                          # This file
+└── SKILL.md                          # Complete technical docs
+```
+
+All scripts wrap the [@didcid/keymaster](https://github.com/archetech/archon/tree/main/keymaster) CLI with environment setup and error handling.
+
+## Real-World Usage
+
+**Morningstar (AI agent):**
+- DID: `did:cid:bagaaieranxnl4gmwyw2nv4imoo5fuwvsa4ihba4clp5l22twztuwevjrevha`
+- Lightning wallet for paid API access
+- Receives tips via Lightning Address
+- Pays for compute resources in real-time
+
+**Use cases already working:**
+- Agent-to-agent service payments
+- Micropayments for API calls
+- Value-4-value content tipping
+- Lightning-gated access control
+
+## Security Model
+
+**What you trust:**
+- Your hardware (runs the Lightning node)
+- Lightning Network (routing and settlement)
+- Mathematics (cryptographic proofs)
+- Open source code (audit everything)
+
+**What you DON'T trust:**
+- Central servers (Lightning is peer-to-peer)
+- Custodians (you control your keys)
+- Banks (no traditional finance involved)
+- Payment processors (direct payments)
+
+**Threat model:**
+- ✅ **Payment censorship:** Lightning is permissionless
+- ✅ **Custody risk:** Non-custodial, you control funds
+- ✅ **Privacy:** Onion-routed payments
+- ✅ **Fake payments:** Cryptographic proof of payment
+- ⚠️ **Key compromise:** If someone gets your keys, they control your funds
+- ⚠️ **Channel force-close:** Funds locked until on-chain settlement
+
+## Comparison to Other Systems
+
+| Feature | archon-lightning | Custodial Wallet | Credit Card | Bank Wire |
+|---------|------------------|------------------|-------------|-----------|
+| **Setup time** | Instant | Email signup | Weeks | Days |
+| **Permission** | None | Email/phone | Credit check | Bank account |
+| **Custody** | Self | Third party | Third party | Third party |
+| **Fees** | ~0.1% | 0-3% | 2-3% | $15-50 |
+| **Settlement** | Instant | Instant-24h | 2-3 days | 1-5 days |
+| **Minimum** | 1 sat (~$0.0001) | Varies | ~$1 | ~$10 |
+| **Agent-friendly** | Yes | Maybe | No | No |
+| **Global** | Yes | Restrictions | Restricted | Restricted |
+| **Privacy** | High | Low | None | None |
+
+## Roadmap
+
+**Current capabilities:**
+- ✅ Wallet creation and management
+- ✅ Invoice generation and payment
+- ✅ Lightning Address zapping
+- ✅ Payment verification
+- ✅ Balance checking and history
+- ✅ DID document integration
+
+**Coming soon:**
+- 🔜 Multi-DID wallet management (one node, many DIDs)
+- 🔜 Subscription payments (recurring Lightning invoices)
+- 🔜 Payment streaming (continuous micropayments)
+- 🔜 Lightning Service Authentication Tokens (LSAT)
+
+## Contributing
+
+Found a bug? Want a feature? Have a use case?
+
+- **Issues:** https://github.com/archetech/agent-skills/issues
+- **Discussions:** https://github.com/archetech/archon/discussions
+- **Archon core:** https://github.com/archetech/archon
+
+## License
+
+Same as parent repo: [agent-skills license](https://github.com/archetech/agent-skills)
+
+## Learn More
+
+- **Lightning Network:** https://lightning.network
+- **BOLT specs:** https://github.com/lightning/bolts
+- **Lightning Address:** https://lightningaddress.com
+- **Archon documentation:** https://github.com/archetech/archon
+- **Complete skill documentation:** [SKILL.md](./SKILL.md)
+
+---
+
+**⚡ Powered by Lightning. Secured by Archon. Built for agents.**

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -264,20 +264,6 @@ All scripts wrap the [@didcid/keymaster](https://github.com/archetech/archon/tre
 - Banks (no traditional finance involved)
 - Payment processors (direct payments)
 
-## Comparison to Other Systems
-
-| Feature | archon-lightning | Custodial Wallet | Credit Card | Bank Wire |
-|---------|------------------|------------------|-------------|-----------|
-| **Setup time** | Instant | Email signup | Weeks | Days |
-| **Permission** | None | Email/phone | Credit check | Bank account |
-| **Custody** | Self | Third party | Third party | Third party |
-| **Fees** | ~0.1% | 0-3% | 2-3% | $15-50 |
-| **Settlement** | Instant | Instant-24h | 2-3 days | 1-5 days |
-| **Minimum** | 1 sat (~$0.0001) | Varies | ~$1 | ~$10 |
-| **Agent-friendly** | Yes | Maybe | No | No |
-| **Global** | Yes | Restrictions | Restricted | Restricted |
-| **Privacy** | High | Low | None | None |
-
 ## Roadmap
 
 **Current capabilities:**

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -73,9 +73,10 @@ Payment verification is built-in - the script automatically verifies before outp
 
 ```bash
 ./scripts/lightning/lightning-zap.sh user@getalby.com 1000 "Great post!"
+# ✅ Payment confirmed
 ```
 
-Send to Lightning Addresses, DIDs, or aliases - all in one command.
+Send to Lightning Addresses, DIDs, or aliases - all in one command. Payment verification is automatic.
 
 ### Payment History
 

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -205,12 +205,18 @@ Publish your Lightning endpoint to your DID document so others can pay you:
 ./scripts/lightning/publish-lightning.sh
 ```
 
-Your DID document now includes:
+Your DID document now includes a Lightning service entry:
 ```json
 {
-  "id": "did:cid:bagaaiera...",
-  "lightning": {
-    "endpoint": "https://..."
+  "didDocument": {
+    "id": "did:cid:bagaaiera...",
+    "service": [
+      {
+        "id": "did:cid:bagaaiera...#lightning",
+        "type": "Lightning",
+        "serviceEndpoint": "http://...onion:4222/invoice/bagaaiera..."
+      }
+    ]
   }
 }
 ```

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -63,10 +63,11 @@ Share that invoice. When paid, sats arrive in your wallet instantly.
 
 ```bash
 ./scripts/lightning/lightning-pay.sh lnbc10u1...
-# Returns: {"paymentHash": "...", "paid": true, "preimage": "..."}
+# ✅ Payment confirmed
+# (or "❌ Payment failed or pending" if payment didn't settle)
 ```
 
-Payment verification is built-in - the script automatically checks that payment settled before returning.
+Payment verification is built-in - the script automatically verifies before outputting success.
 
 ### Zap via Lightning Address
 
@@ -145,42 +146,12 @@ A payment hash does NOT mean the payment succeeded. Lightning payments can:
 **Our `lightning-pay.sh` script handles this automatically:**
 
 ```bash
-# ✅ Automatic verification built-in
-result=$(./scripts/lightning/lightning-pay.sh lnbc10u1...)
-# Returns: {"paymentHash": "...", "paid": true, "preimage": "..."}
-
-if [ "$(echo "$result" | jq -r .paid)" = "true" ]; then
-  echo "✅ Payment confirmed"
-else
-  echo "❌ Payment failed"
-  exit 1
-fi
+./scripts/lightning/lightning-pay.sh lnbc10u1...
+# ✅ Payment confirmed
+# (or exits with error if payment failed)
 ```
 
-**If using keymaster directly, you MUST verify manually:**
-
-```bash
-# ❌ WRONG - Assumes payment hash = success
-result=$(npx @didcid/keymaster lightning-pay lnbc10u1...)
-echo "Payment sent!" # NOPE!
-
-# ✅ CORRECT - Verify payment settled
-result=$(npx @didcid/keymaster lightning-pay lnbc10u1...)
-hash=$(echo "$result" | jq -r .paymentHash)
-status=$(npx @didcid/keymaster lightning-check "$hash" | jq -r .paid)
-
-if [ "$status" = "true" ]; then
-  echo "✅ Payment confirmed"
-else
-  echo "❌ Payment failed or pending"
-  exit 1
-fi
-```
-
-This pattern prevents:
-- False confirmation (thinking you paid when you didn't)
-- Double payments (retrying when payment actually succeeded)
-- Lost funds (overpaying due to confusion)
+The script verifies the payment settled and outputs a clear success/failure message. No manual checking needed.
 
 ### Lightning Address
 

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -54,10 +54,10 @@ Your DID now has a Lightning wallet. That's it.
 
 ```bash
 ./scripts/lightning/lightning-invoice.sh 1000 "Coffee payment"
-# Returns BOLT11 invoice: lnbc10u1...
+# Returns: {"paymentRequest": "lnbc10u1...", "paymentHash": "..."}
 ```
 
-Share that invoice. When paid, sats arrive in your wallet instantly.
+Extract the `paymentRequest` value and share it. When paid, sats arrive in your wallet instantly.
 
 ### Pay an Invoice
 

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -10,7 +10,7 @@ Send and receive Bitcoin over Lightning. No custody. No permission. Just your DI
 
 - ⚡ **Lightning wallets for DIDs** - Each DID can have its own Lightning wallet
 - 💸 **Send/receive sats** - Pay BOLT11 invoices or create invoices to receive payments
-- ⚡ **Lightning Address zaps** - Send to `user@domain.com` Lightning Addresses
+- ⚡ **Lightning Address zaps** - Send to `user@domain.com` Lightning Addresses, DIDs, or aliases
 - ✅ **Payment verification** - Cryptographic proof that payments settled
 - 📊 **Payment history** - Track all Lightning transactions
 - 🔗 **DID integration** - Publish your Lightning endpoint to your DID document
@@ -63,16 +63,10 @@ Share that invoice. When paid, sats arrive in your wallet instantly.
 
 ```bash
 ./scripts/lightning/lightning-pay.sh lnbc10u1...
-# Returns payment hash
+# Returns: {"paymentHash": "...", "paid": true, "preimage": "..."}
 ```
 
-**Critical:** Always verify payments settled!
-
-```bash
-HASH=$(./scripts/lightning/lightning-pay.sh lnbc10u1... | jq -r .paymentHash)
-./scripts/lightning/lightning-check.sh "$HASH"
-# {"paid": true} means payment confirmed
-```
+Payment verification is built-in - the script automatically checks that payment settled before returning.
 
 ### Zap via Lightning Address
 
@@ -148,17 +142,32 @@ A payment hash does NOT mean the payment succeeded. Lightning payments can:
 - Fail (no route, insufficient balance)
 - Time out (invoice expired)
 
-**Always verify with `lightning-check`:**
+**Our `lightning-pay.sh` script handles this automatically:**
+
+```bash
+# ✅ Automatic verification built-in
+result=$(./scripts/lightning/lightning-pay.sh lnbc10u1...)
+# Returns: {"paymentHash": "...", "paid": true, "preimage": "..."}
+
+if [ "$(echo "$result" | jq -r .paid)" = "true" ]; then
+  echo "✅ Payment confirmed"
+else
+  echo "❌ Payment failed"
+  exit 1
+fi
+```
+
+**If using keymaster directly, you MUST verify manually:**
 
 ```bash
 # ❌ WRONG - Assumes payment hash = success
-result=$(./scripts/lightning/lightning-pay.sh lnbc10u1...)
+result=$(npx @didcid/keymaster lightning-pay lnbc10u1...)
 echo "Payment sent!" # NOPE!
 
 # ✅ CORRECT - Verify payment settled
-result=$(./scripts/lightning/lightning-pay.sh lnbc10u1...)
+result=$(npx @didcid/keymaster lightning-pay lnbc10u1...)
 hash=$(echo "$result" | jq -r .paymentHash)
-status=$(./scripts/lightning/lightning-check.sh "$hash" | jq -r .paid)
+status=$(npx @didcid/keymaster lightning-check "$hash" | jq -r .paid)
 
 if [ "$status" = "true" ]; then
   echo "✅ Payment confirmed"

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -287,14 +287,6 @@ All scripts wrap the [@didcid/keymaster](https://github.com/archetech/archon/tre
 - Banks (no traditional finance involved)
 - Payment processors (direct payments)
 
-**Threat model:**
-- ✅ **Payment censorship:** Lightning is permissionless
-- ✅ **Custody risk:** Non-custodial, you control funds
-- ✅ **Privacy:** Onion-routed payments
-- ✅ **Fake payments:** Cryptographic proof of payment
-- ⚠️ **Key compromise:** If someone gets your keys, they control your funds
-- ⚠️ **Channel force-close:** Funds locked until on-chain settlement
-
 ## Comparison to Other Systems
 
 | Feature | archon-lightning | Custodial Wallet | Credit Card | Bank Wire |
@@ -318,12 +310,6 @@ All scripts wrap the [@didcid/keymaster](https://github.com/archetech/archon/tre
 - ✅ Payment verification
 - ✅ Balance checking and history
 - ✅ DID document integration
-
-**Coming soon:**
-- 🔜 Multi-DID wallet management (one node, many DIDs)
-- 🔜 Subscription payments (recurring Lightning invoices)
-- 🔜 Payment streaming (continuous micropayments)
-- 🔜 Lightning Service Authentication Tokens (LSAT)
 
 ## Contributing
 

--- a/archon-lightning/README.md
+++ b/archon-lightning/README.md
@@ -210,8 +210,7 @@ Your DID document now includes:
 {
   "id": "did:cid:bagaaiera...",
   "lightning": {
-    "endpoint": "https://...",
-    "address": "user@domain.com"
+    "endpoint": "https://..."
   }
 }
 ```

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -131,15 +131,16 @@ Pay a BOLT11 invoice with automatic payment verification.
 - `bolt11` - BOLT11 invoice string
 - `id` - (optional) DID alias to pay from
 
-**Returns:** Combined payment result with verification status
+**Output:** Success or failure message with exit code
 
 **Example:**
 ```bash
 ./scripts/lightning/lightning-pay.sh lnbc10u1p...
-# {"paymentHash": "a3f7b8c9...", "paid": true, "preimage": "..."}
+# ✅ Payment confirmed
+# (exits 0 on success, 1 on failure)
 ```
 
-The script automatically calls `lightning-check` after paying to verify the payment settled.
+The script automatically verifies the payment settled before outputting success.
 
 ### ⚠️ Payment Verification Pattern (CRITICAL)
 
@@ -148,41 +149,17 @@ The script automatically calls `lightning-check` after paying to verify the paym
 **Our `lightning-pay.sh` script handles verification automatically:**
 
 ```bash
-# Automatic verification built-in
-result=$(./scripts/lightning/lightning-pay.sh lnbc10u1p...)
-# Returns: {"paymentHash": "...", "paid": true, "preimage": "..."}
-
-# Check result
-if [ "$(echo "$result" | jq -r .paid)" = "true" ]; then
-  echo "✅ Payment confirmed"
-else
-  echo "❌ Payment failed"
-  exit 1
-fi
+./scripts/lightning/lightning-pay.sh lnbc10u1p...
+# ✅ Payment confirmed
+# (or "❌ Payment failed or pending" + exit 1)
 ```
 
-**If using `keymaster` directly, you MUST verify manually:**
+The script verifies the payment settled and outputs a clear success/failure message. No manual checking needed.
 
-```bash
-# Step 1: Pay invoice
-result=$(npx @didcid/keymaster lightning-pay lnbc10u1p...)
-hash=$(echo "$result" | jq -r .paymentHash)
-
-# Step 2: VERIFY payment settled
-status=$(npx @didcid/keymaster lightning-check "$hash" | jq -r .paid)
-
-# Step 3: Check result
-if [ "$status" = "true" ]; then
-  echo "✅ Payment confirmed"
-else
-  echo "❌ Payment failed or pending"
-  exit 1
-fi
-```
-
-**Why this matters:**
-- Prevents false confirmation (thinking you paid when you didn't)
-- Avoids double payments (retrying when payment succeeded)
+**Why verification matters:**
+- Payment hash ≠ success (can fail after returning hash)
+- Prevents false confirmation
+- Avoids double payments
 - Protects against lost funds
 
 ### Verify Payment Status

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -79,10 +79,8 @@ Examples:
 Returns current balance in satoshis.
 
 Example output:
-```json
-{
-  "balance": 50000
-}
+```
+2257 sats
 ```
 
 ## Receiving Payments
@@ -100,17 +98,18 @@ Creates a BOLT11 invoice to receive payment.
 - `memo` - Description/memo for the invoice
 - `id` - (optional) DID alias, defaults to current identity
 
-**Examples:**
+**Example:**
 ```bash
-# Create invoice for 1000 sats
 ./scripts/lightning/lightning-invoice.sh 1000 "Coffee payment"
-# Returns: lnbc10u1p...
-
-# Invoice from specific DID
-./scripts/lightning/lightning-invoice.sh 5000 "Consulting fee" work-persona
 ```
 
-**Output:** BOLT11 invoice string (e.g., `lnbc10u1p...`)
+**Output:**
+```json
+{
+  "paymentRequest": "lnbc10u1p...",
+  "paymentHash": "a3f7b8c9..."
+}
+```
 
 Share this invoice with the payer. They can:
 - Scan as QR code
@@ -231,24 +230,16 @@ Send sats to a Lightning Address, DID, or alias.
 Show all Lightning payments (sent and received).
 
 **Example output:**
-```json
-[
-  {
-    "type": "sent",
-    "amount": 1000,
-    "timestamp": "2026-03-05T10:15:00Z",
-    "paymentHash": "a3f7b8c9...",
-    "settled": true
-  },
-  {
-    "type": "received",
-    "amount": 5000,
-    "timestamp": "2026-03-05T09:30:00Z",
-    "invoice": "lnbc50u1p...",
-    "settled": true
-  }
-]
 ```
+2026/03/05 11:17:38  -100 sats "Payment memo"
+2026/03/04 17:08:14  +20 sats "Received payment"
+2026/03/03 17:16:31  +25 sats "Test invoice"
+```
+
+Format: `YYYY/MM/DD HH:MM:SS  [+/-]amount sats ["memo"]`
+- Negative amounts = payments sent
+- Positive amounts = payments received
+- Memo is optional
 
 ## DID Integration
 

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -125,19 +125,21 @@ Share this invoice with the payer. They can:
 ./scripts/lightning/lightning-pay.sh <bolt11> [id]
 ```
 
-Pay a BOLT11 invoice.
+Pay a BOLT11 invoice with automatic payment verification.
 
 **Arguments:**
 - `bolt11` - BOLT11 invoice string
 - `id` - (optional) DID alias to pay from
 
-**Returns:** Payment hash (NOT confirmation of success!)
+**Returns:** Combined payment result with verification status
 
 **Example:**
 ```bash
 ./scripts/lightning/lightning-pay.sh lnbc10u1p...
-# {"paymentHash": "a3f7b8c9..."}
+# {"paymentHash": "a3f7b8c9...", "paid": true, "preimage": "..."}
 ```
+
+The script automatically calls `lightning-check` after paying to verify the payment settled.
 
 ### ⚠️ Payment Verification Pattern (CRITICAL)
 

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -1,0 +1,648 @@
+---
+name: archon-lightning
+description: Lightning Network payments via Archon DIDs - create wallets, send/receive sats, verify payments, Lightning Address zaps
+metadata:
+  openclaw:
+    requires:
+      env:
+        - ARCHON_WALLET_PATH
+        - ARCHON_PASSPHRASE
+        - ARCHON_GATEKEEPER_URL
+      bins:
+        - node
+        - npx
+      anyBins:
+        - jq
+    primaryEnv: ARCHON_PASSPHRASE
+    emoji: "⚡"
+---
+
+# Archon Lightning - Lightning Network Payments for DIDs
+
+Lightning Network integration for Archon decentralized identities. Send and receive Bitcoin over Lightning using your DID.
+
+**Related skills:**
+- `archon-keymaster` — Core DID identity management
+- `archon-vault` — Encrypted backups
+
+## Capabilities
+
+- **Lightning Wallet Management** - Create Lightning wallets for DIDs
+- **Invoice Generation** - Create BOLT11 invoices to receive payments
+- **Invoice Payment** - Pay BOLT11 invoices
+- **Payment Verification** - Verify payments settled (critical security pattern)
+- **Lightning Address Zapping** - Send to Lightning Addresses (`user@domain.com`)
+- **Payment History** - Track all Lightning transactions
+- **Balance Checking** - Query wallet balance
+- **DID Integration** - Publish Lightning endpoint to DID document
+- **Invoice Decoding** - Inspect BOLT11 invoice details
+
+## Prerequisites
+
+- Node.js installed (for `npx @didcid/keymaster`)
+- Archon identity configured (`~/.archon.env` with `ARCHON_WALLET_PATH`, `ARCHON_PASSPHRASE`)
+- `jq` recommended for JSON parsing
+
+All created by `archon-keymaster` setup. If you don't have Archon configured yet, see the `archon-keymaster` skill first.
+
+## Security Notes
+
+This skill handles Lightning Network payments:
+
+1. **Non-custodial**: You control your Lightning node and private keys
+2. **Payment verification is critical**: Always verify payments with `lightning-check` (see Payment Verification Pattern below)
+3. **Environment access**: Scripts source `~/.archon.env` for wallet access
+4. **Network connectivity**: Connects to Lightning Network via Archon gatekeeper
+
+## Quick Start
+
+### Create Lightning Wallet
+
+```bash
+./scripts/lightning/add-lightning.sh [id]
+```
+
+Creates a Lightning wallet for your current DID (or specified DID alias).
+
+Examples:
+```bash
+./scripts/lightning/add-lightning.sh          # Current DID
+./scripts/lightning/add-lightning.sh work     # Specific DID alias
+```
+
+### Check Balance
+
+```bash
+./scripts/lightning/lightning-balance.sh [id]
+```
+
+Returns current balance in satoshis.
+
+Example output:
+```json
+{
+  "balance": 50000
+}
+```
+
+## Receiving Payments
+
+### Create Invoice
+
+```bash
+./scripts/lightning/lightning-invoice.sh <amount> <memo> [id]
+```
+
+Creates a BOLT11 invoice to receive payment.
+
+**Arguments:**
+- `amount` - Amount in satoshis (1000 = 0.00001 BTC)
+- `memo` - Description/memo for the invoice
+- `id` - (optional) DID alias, defaults to current identity
+
+**Examples:**
+```bash
+# Create invoice for 1000 sats
+./scripts/lightning/lightning-invoice.sh 1000 "Coffee payment"
+# Returns: lnbc10u1p...
+
+# Invoice from specific DID
+./scripts/lightning/lightning-invoice.sh 5000 "Consulting fee" work-persona
+```
+
+**Output:** BOLT11 invoice string (e.g., `lnbc10u1p...`)
+
+Share this invoice with the payer. They can:
+- Scan as QR code
+- Paste into any Lightning wallet
+- Pay via Lightning-enabled app
+
+## Sending Payments
+
+### Pay Invoice (Basic)
+
+```bash
+./scripts/lightning/lightning-pay.sh <bolt11> [id]
+```
+
+Pay a BOLT11 invoice.
+
+**Arguments:**
+- `bolt11` - BOLT11 invoice string
+- `id` - (optional) DID alias to pay from
+
+**Returns:** Payment hash (NOT confirmation of success!)
+
+**Example:**
+```bash
+./scripts/lightning/lightning-pay.sh lnbc10u1p...
+# {"paymentHash": "a3f7b8c9..."}
+```
+
+### ⚠️ Payment Verification Pattern (CRITICAL)
+
+**The payment hash is NOT proof of payment!** Lightning payments can fail, time out, or remain pending.
+
+**Always verify payments settled:**
+
+```bash
+# Step 1: Pay invoice
+result=$(./scripts/lightning/lightning-pay.sh lnbc10u1p...)
+hash=$(echo "$result" | jq -r .paymentHash)
+
+# Step 2: VERIFY payment settled
+status=$(./scripts/lightning/lightning-check.sh "$hash" | jq -r .paid)
+
+# Step 3: Check result
+if [ "$status" = "true" ]; then
+  echo "✅ Payment confirmed"
+else
+  echo "❌ Payment failed or pending"
+  exit 1
+fi
+```
+
+**Why this matters:**
+- Prevents false confirmation (thinking you paid when you didn't)
+- Avoids double payments (retrying when payment succeeded)
+- Protects against lost funds
+
+### Verify Payment Status
+
+```bash
+./scripts/lightning/lightning-check.sh <paymentHash> [id]
+```
+
+Check whether a payment settled.
+
+**Arguments:**
+- `paymentHash` - Payment hash from `lightning-pay`
+- `id` - (optional) DID alias
+
+**Returns:**
+```json
+{
+  "paid": true,
+  "preimage": "...",
+  "amount": 1000
+}
+```
+
+- `"paid": true` — Payment settled successfully
+- `"paid": false` — Payment failed or still pending
+
+### Lightning Address Zapping
+
+```bash
+./scripts/lightning/lightning-zap.sh <recipient> <amount> [memo] [id]
+```
+
+Send sats to a Lightning Address, DID, or alias.
+
+**Arguments:**
+- `recipient` - Lightning Address (`user@domain.com`), DID, or alias
+- `amount` - Amount in satoshis
+- `memo` - (optional) Message/memo
+- `id` - (optional) DID alias to send from
+
+**Examples:**
+```bash
+# Zap to Lightning Address
+./scripts/lightning/lightning-zap.sh user@getalby.com 1000 "Great post!"
+
+# Zap to DID
+./scripts/lightning/lightning-zap.sh did:cid:bagaaiera... 5000
+
+# Zap to alias
+./scripts/lightning/lightning-zap.sh alice 2000 "Coffee"
+```
+
+**Returns:** Payment result (includes payment hash, verify with `lightning-check`)
+
+**What it does:**
+1. Resolves Lightning Address to LNURL endpoint
+2. Requests invoice for specified amount
+3. Pays invoice
+4. Returns payment hash (you still need to verify!)
+
+## Payment History
+
+### List Payments
+
+```bash
+./scripts/lightning/lightning-payments.sh [id]
+```
+
+Show all Lightning payments (sent and received).
+
+**Example output:**
+```json
+[
+  {
+    "type": "sent",
+    "amount": 1000,
+    "timestamp": "2026-03-05T10:15:00Z",
+    "paymentHash": "a3f7b8c9...",
+    "settled": true
+  },
+  {
+    "type": "received",
+    "amount": 5000,
+    "timestamp": "2026-03-05T09:30:00Z",
+    "invoice": "lnbc50u1p...",
+    "settled": true
+  }
+]
+```
+
+## DID Integration
+
+### Publish Lightning Endpoint
+
+```bash
+./scripts/lightning/publish-lightning.sh [id]
+```
+
+Add your Lightning endpoint to your DID document.
+
+**What it does:**
+- Updates your DID document with Lightning service info
+- Makes your Lightning endpoint publicly discoverable
+- Others can look up your DID and pay you
+
+**Example:**
+```bash
+./scripts/lightning/publish-lightning.sh
+
+# Your DID document now includes:
+# {
+#   "id": "did:cid:bagaaiera...",
+#   "service": [{
+#     "type": "LightningNode",
+#     "serviceEndpoint": "..."
+#   }]
+# }
+```
+
+### Unpublish Lightning Endpoint
+
+```bash
+./scripts/lightning/unpublish-lightning.sh [id]
+```
+
+Remove Lightning endpoint from your DID document.
+
+## Utilities
+
+### Decode Invoice
+
+```bash
+./scripts/lightning/lightning-decode.sh <bolt11>
+```
+
+Inspect BOLT11 invoice details before paying.
+
+**Example output:**
+```json
+{
+  "amount": 1000,
+  "description": "Coffee payment",
+  "paymentHash": "a3f7b8c9...",
+  "timestamp": 1709635800,
+  "expiry": 3600,
+  "destination": "03..."
+}
+```
+
+**Use cases:**
+- Verify amount before paying
+- Check invoice hasn't expired
+- Confirm recipient/description
+- Extract payment hash for tracking
+
+## Complete Workflow Examples
+
+### Example 1: Simple Payment
+
+```bash
+# Alice creates invoice
+INVOICE=$(./scripts/lightning/lightning-invoice.sh 1000 "Coffee")
+echo "Invoice: $INVOICE"
+
+# Bob pays invoice
+RESULT=$(./scripts/lightning/lightning-pay.sh "$INVOICE")
+HASH=$(echo "$RESULT" | jq -r .paymentHash)
+
+# Bob verifies payment
+STATUS=$(./scripts/lightning/lightning-check.sh "$HASH" | jq -r .paid)
+if [ "$STATUS" = "true" ]; then
+  echo "✅ Payment confirmed!"
+fi
+
+# Alice checks balance
+./scripts/lightning/lightning-balance.sh
+```
+
+### Example 2: Lightning Address Zap
+
+```bash
+# Zap creator via Lightning Address
+./scripts/lightning/lightning-zap.sh creator@getalby.com 5000 "Love your content!"
+
+# Zap returns payment hash, verify it
+HASH=$(./scripts/lightning/lightning-zap.sh creator@getalby.com 5000 | jq -r .paymentHash)
+./scripts/lightning/lightning-check.sh "$HASH"
+```
+
+### Example 3: Invoice Verification
+
+```bash
+# Receive a BOLT11 invoice from someone
+INVOICE="lnbc10u1p..."
+
+# Decode to verify amount and recipient
+./scripts/lightning/lightning-decode.sh "$INVOICE"
+# Check amount, description, expiry
+
+# If looks good, pay it
+RESULT=$(./scripts/lightning/lightning-pay.sh "$INVOICE")
+HASH=$(echo "$RESULT" | jq -r .paymentHash)
+
+# CRITICAL: Verify payment settled
+./scripts/lightning/lightning-check.sh "$HASH"
+```
+
+### Example 4: Multi-DID Wallet Management
+
+```bash
+# Create wallets for different personas
+./scripts/lightning/add-lightning.sh personal
+./scripts/lightning/add-lightning.sh work
+./scripts/lightning/add-lightning.sh project
+
+# Check balances
+./scripts/lightning/lightning-balance.sh personal
+./scripts/lightning/lightning-balance.sh work
+./scripts/lightning/lightning-balance.sh project
+
+# Pay from specific wallet
+./scripts/lightning/lightning-pay.sh lnbc10u1p... work
+```
+
+### Example 5: Publishing Lightning to DID
+
+```bash
+# Create Lightning wallet
+./scripts/lightning/add-lightning.sh
+
+# Publish to DID document
+./scripts/lightning/publish-lightning.sh
+
+# Others can now discover your Lightning endpoint
+# They look up your DID and see your Lightning service
+
+# Later, if you want to unpublish:
+./scripts/lightning/unpublish-lightning.sh
+```
+
+## Environment Setup
+
+All scripts require:
+
+```bash
+source ~/.nvm/nvm.sh   # Load Node.js (adds npx to PATH)
+source ~/.archon.env   # Load wallet path and passphrase
+```
+
+These are automatically sourced by the wrapper scripts.
+
+**Environment variables (`~/.archon.env`):**
+- `ARCHON_WALLET_PATH` - Path to your wallet file
+- `ARCHON_PASSPHRASE` - Wallet encryption passphrase
+- `ARCHON_GATEKEEPER_URL` - (optional) Gatekeeper endpoint
+
+## Advanced Usage
+
+### Lightning Node Details
+
+Archon Lightning wallets are:
+- **Non-custodial** - You control the keys
+- **Self-hosted** - Runs via Archon gatekeeper
+- **DID-integrated** - Same identity across protocols
+
+The wallet is managed by `@didcid/keymaster` which interfaces with Lightning infrastructure.
+
+### Payment Amounts
+
+Lightning amounts are in **satoshis**:
+- 1 satoshi = 0.00000001 BTC
+- 1000 sats = 0.00001 BTC (~$0.01 at $100k BTC)
+- 100,000 sats = 0.001 BTC (~$1 at $100k BTC)
+
+Minimum payment typically 1 sat, maximum depends on channel capacity.
+
+### Invoice Expiry
+
+BOLT11 invoices typically expire after 1 hour. Check expiry with:
+
+```bash
+./scripts/lightning/lightning-decode.sh lnbc10u1p... | jq .expiry
+```
+
+### Lightning Address Resolution
+
+Lightning Addresses resolve via LNURL:
+
+```
+user@domain.com
+→ Query: https://domain.com/.well-known/lnurlp/user
+→ Get invoice endpoint
+→ Request invoice for amount
+→ Pay invoice
+```
+
+The `lightning-zap.sh` script handles this automatically.
+
+## Error Handling
+
+### Common Issues
+
+**"No route found":**
+- Lightning Network couldn't find path to recipient
+- Try smaller amount or wait for better routing
+
+**"Insufficient balance":**
+- Check balance: `./scripts/lightning/lightning-balance.sh`
+- Add funds to your wallet
+
+**"Invoice expired":**
+- Request new invoice from recipient
+- Check expiry: `./scripts/lightning/lightning-decode.sh`
+
+**"Payment failed":**
+- Always verify with `lightning-check`
+- Payment hash ≠ success
+- May need to retry with new invoice
+
+### Verification Workflow
+
+```bash
+# 1. Attempt payment
+RESULT=$(./scripts/lightning/lightning-pay.sh "$INVOICE" 2>&1)
+
+# 2. Check for errors
+if ! echo "$RESULT" | jq -e .paymentHash > /dev/null 2>&1; then
+  echo "Payment failed: $RESULT"
+  exit 1
+fi
+
+# 3. Extract payment hash
+HASH=$(echo "$RESULT" | jq -r .paymentHash)
+
+# 4. Verify payment settled
+for i in {1..5}; do
+  STATUS=$(./scripts/lightning/lightning-check.sh "$HASH" | jq -r .paid)
+  if [ "$STATUS" = "true" ]; then
+    echo "✅ Payment confirmed"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "⏳ Payment still pending or failed"
+exit 1
+```
+
+## Security Best Practices
+
+### Payment Verification
+
+**Always verify payments settled:**
+```bash
+# ❌ WRONG
+./scripts/lightning/lightning-pay.sh lnbc10u1p...
+echo "Paid!" # NO!
+
+# ✅ CORRECT
+HASH=$(./scripts/lightning/lightning-pay.sh lnbc10u1p... | jq -r .paymentHash)
+./scripts/lightning/lightning-check.sh "$HASH" | jq -r .paid
+```
+
+### Invoice Validation
+
+**Before paying, verify:**
+- Amount is correct
+- Recipient is expected
+- Invoice hasn't expired
+- Description matches expectation
+
+```bash
+./scripts/lightning/lightning-decode.sh lnbc10u1p...
+# Check output before paying
+```
+
+### Key Security
+
+- Lightning private keys derived from DID seed
+- Keep `ARCHON_PASSPHRASE` secure
+- Backup your 12-word mnemonic (see `archon-vault` skill)
+- Use separate DIDs for different risk profiles
+
+### Amount Limits
+
+- Start with small amounts for testing
+- Lightning is for micropayments (< $100 typical)
+- Large amounts should use on-chain Bitcoin
+- Check balance before sending
+
+## Troubleshooting
+
+### "Command not found: npx"
+
+```bash
+source ~/.nvm/nvm.sh
+```
+
+### "Cannot read wallet"
+
+```bash
+source ~/.archon.env
+ls -la "$ARCHON_WALLET_PATH"
+# Ensure wallet file exists and is readable
+```
+
+### "Payment hash not found"
+
+Payment may still be pending or failed. Wait 5-10 seconds and try `lightning-check` again.
+
+### "Lightning wallet not found"
+
+```bash
+./scripts/lightning/add-lightning.sh
+# Creates wallet for current DID
+```
+
+### Network Issues
+
+If Archon gatekeeper is unreachable:
+```bash
+echo $ARCHON_GATEKEEPER_URL
+# Verify URL is correct
+
+# Try default gatekeeper
+unset ARCHON_GATEKEEPER_URL
+./scripts/lightning/lightning-balance.sh
+```
+
+## Data Storage
+
+Lightning payment data is stored:
+- **Locally:** Wallet state in `~/.archon.wallet.json`
+- **Network:** Channel state on Lightning Network
+- **DID document:** Public endpoint (if published)
+
+No payment history or balances are exposed publicly unless you explicitly publish them.
+
+## Use Cases
+
+**Agent-to-Agent Payments:**
+- Pay for API access
+- Skill marketplace transactions
+- Service subscriptions
+- Bounty payments
+
+**Content Monetization:**
+- Paywalled articles
+- Per-use API access
+- Streaming sats for media
+- Microtips for social posts
+
+**Real-Time Payments:**
+- Pay-per-compute
+- Storage payments
+- Data feed subscriptions
+- Time-based access
+
+**Value-4-Value:**
+- Podcast boosts
+- Creator support
+- Open source tips
+- P2P payments
+
+## References
+
+- Archon documentation: https://github.com/archetech/archon
+- Keymaster reference: https://github.com/archetech/archon/tree/main/keymaster
+- Lightning Network: https://lightning.network
+- BOLT specifications: https://github.com/lightning/bolts
+- Lightning Address: https://lightningaddress.com
+
+## Related Skills
+
+- **archon-keymaster** — Core DID management and credentials
+- **archon-vault** — Encrypted backups and disaster recovery
+- **archon-cashu** — Ecash tokens with DID locking
+
+---
+
+**⚡ Powered by Lightning. Secured by Archon. Built for agents.**

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -394,6 +394,30 @@ HASH=$(echo "$RESULT" | jq -r .paymentHash)
 ./scripts/lightning/unpublish-lightning.sh
 ```
 
+### Example 6: Sending Invoice via Dmail
+
+```bash
+# Alice creates an invoice for 5000 sats
+INVOICE_JSON=$(npx @didcid/keymaster lightning-invoice 5000 "Consulting fee")
+INVOICE=$(echo "$INVOICE_JSON" | jq -r .paymentRequest)
+
+# Alice sends the invoice to Bob via dmail
+npx @didcid/keymaster send-dmail \
+  "did:cid:bob..." \
+  "Invoice for consulting work" \
+  "Please pay this invoice: $INVOICE"
+
+# Bob receives the dmail, extracts the invoice, and pays
+npx @didcid/keymaster lightning-pay "$INVOICE"
+# ✅ Payment confirmed
+
+# Alice checks her payment history
+npx @didcid/keymaster lightning-payments
+# Shows the received payment
+```
+
+**Why this matters:** Agents can request payment without needing email, phone numbers, or centralized messaging platforms. Just DIDs + Lightning + dmail.
+
 ## Environment Setup
 
 All scripts require:

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -157,9 +157,7 @@ The script verifies the payment settled and outputs a clear success/failure mess
 
 **Why verification matters:**
 - Payment hash ≠ success (can fail after returning hash)
-- Prevents false confirmation
-- Avoids double payments
-- Protects against lost funds
+- Prevents false confirmation (thinking you paid when you didn't)
 
 ### Verify Payment Status
 

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -50,7 +50,7 @@ All created by `archon-keymaster` setup. If you don't have Archon configured yet
 This skill handles Lightning Network payments:
 
 1. **Non-custodial**: You control your Lightning node and private keys
-2. **Payment verification is critical**: Always verify payments with `lightning-check` (see Payment Verification Pattern below)
+2. **Payment verification is built-in**: `lightning-pay.sh` automatically verifies payments; if using keymaster directly, you must verify manually with `lightning-check` (see Payment Verification Pattern below)
 3. **Environment access**: Scripts source `~/.archon.env` for wallet access
 4. **Network connectivity**: Connects to Lightning Network via Archon gatekeeper
 
@@ -143,15 +143,31 @@ Pay a BOLT11 invoice.
 
 **The payment hash is NOT proof of payment!** Lightning payments can fail, time out, or remain pending.
 
-**Always verify payments settled:**
+**Our `lightning-pay.sh` script handles verification automatically:**
+
+```bash
+# Automatic verification built-in
+result=$(./scripts/lightning/lightning-pay.sh lnbc10u1p...)
+# Returns: {"paymentHash": "...", "paid": true, "preimage": "..."}
+
+# Check result
+if [ "$(echo "$result" | jq -r .paid)" = "true" ]; then
+  echo "✅ Payment confirmed"
+else
+  echo "❌ Payment failed"
+  exit 1
+fi
+```
+
+**If using `keymaster` directly, you MUST verify manually:**
 
 ```bash
 # Step 1: Pay invoice
-result=$(./scripts/lightning/lightning-pay.sh lnbc10u1p...)
+result=$(npx @didcid/keymaster lightning-pay lnbc10u1p...)
 hash=$(echo "$result" | jq -r .paymentHash)
 
 # Step 2: VERIFY payment settled
-status=$(./scripts/lightning/lightning-check.sh "$hash" | jq -r .paid)
+status=$(npx @didcid/keymaster lightning-check "$hash" | jq -r .paid)
 
 # Step 3: Check result
 if [ "$status" = "true" ]; then
@@ -410,11 +426,10 @@ HASH=$(echo "$RESULT" | jq -r .paymentHash)
 All scripts require:
 
 ```bash
-source ~/.nvm/nvm.sh   # Load Node.js (adds npx to PATH)
 source ~/.archon.env   # Load wallet path and passphrase
 ```
 
-These are automatically sourced by the wrapper scripts.
+This is automatically sourced by the wrapper scripts. `npx` is used to run keymaster, so no nvm sourcing is needed.
 
 **Environment variables (`~/.archon.env`):**
 - `ARCHON_WALLET_PATH` - Path to your wallet file
@@ -559,9 +574,14 @@ HASH=$(./scripts/lightning/lightning-pay.sh lnbc10u1p... | jq -r .paymentHash)
 
 ### "Command not found: npx"
 
+Ensure Node.js is installed and in your PATH:
+
 ```bash
-source ~/.nvm/nvm.sh
+node --version  # Should show v16 or newer
+npx --version   # Should show npm version
 ```
+
+If not installed, install Node.js via your package manager or from https://nodejs.org
 
 ### "Cannot read wallet"
 

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -262,11 +262,14 @@ Add your Lightning endpoint to your DID document.
 
 # Your DID document now includes:
 # {
-#   "id": "did:cid:bagaaiera...",
-#   "service": [{
-#     "type": "LightningNode",
-#     "serviceEndpoint": "..."
-#   }]
+#   "didDocument": {
+#     "id": "did:cid:bagaaiera...",
+#     "service": [{
+#       "id": "did:cid:bagaaiera...#lightning",
+#       "type": "Lightning",
+#       "serviceEndpoint": "http://...onion:4222/invoice/bagaaiera..."
+#     }]
+#   }
 # }
 ```
 

--- a/archon-lightning/SKILL.md
+++ b/archon-lightning/SKILL.md
@@ -211,7 +211,16 @@ Send sats to a Lightning Address, DID, or alias.
 ./scripts/lightning/lightning-zap.sh alice 2000 "Coffee"
 ```
 
-**Returns:** Payment result (includes payment hash, verify with `lightning-check`)
+**Output:** Success or failure message with exit code
+
+**Example:**
+```bash
+./scripts/lightning/lightning-zap.sh user@getalby.com 1000 "Great post!"
+# ✅ Payment confirmed
+# (exits 0 on success, 1 on failure)
+```
+
+The script automatically verifies the payment settled before outputting success.
 
 **What it does:**
 1. Resolves Lightning Address to LNURL endpoint
@@ -337,10 +346,9 @@ fi
 ```bash
 # Zap creator via Lightning Address
 ./scripts/lightning/lightning-zap.sh creator@getalby.com 5000 "Love your content!"
+# ✅ Payment confirmed
 
-# Zap returns payment hash, verify it
-HASH=$(./scripts/lightning/lightning-zap.sh creator@getalby.com 5000 | jq -r .paymentHash)
-./scripts/lightning/lightning-check.sh "$HASH"
+# Payment verification is automatic - no manual checking needed
 ```
 
 ### Example 3: Invoice Verification

--- a/archon-lightning/scripts/lightning/add-lightning.sh
+++ b/archon-lightning/scripts/lightning/add-lightning.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# add-lightning.sh - Create Lightning wallet for a DID
+# Usage: ./add-lightning.sh [id]
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster add-lightning "$@"

--- a/archon-lightning/scripts/lightning/add-lightning.sh
+++ b/archon-lightning/scripts/lightning/add-lightning.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # add-lightning.sh - Create Lightning wallet for a DID
 # Usage: ./add-lightning.sh [id]
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster add-lightning "$@"

--- a/archon-lightning/scripts/lightning/lightning-balance.sh
+++ b/archon-lightning/scripts/lightning/lightning-balance.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # lightning-balance.sh - Check Lightning wallet balance
 # Usage: ./lightning-balance.sh [id]
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster lightning-balance "$@"

--- a/archon-lightning/scripts/lightning/lightning-balance.sh
+++ b/archon-lightning/scripts/lightning/lightning-balance.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-balance.sh - Check Lightning wallet balance
+# Usage: ./lightning-balance.sh [id]
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-balance "$@"

--- a/archon-lightning/scripts/lightning/lightning-check.sh
+++ b/archon-lightning/scripts/lightning/lightning-check.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 # Usage: ./lightning-check.sh <paymentHash> [id]
 # Returns: {"paid": true|false, ...}
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster lightning-check "$@"

--- a/archon-lightning/scripts/lightning/lightning-check.sh
+++ b/archon-lightning/scripts/lightning/lightning-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-check.sh - Verify payment status
+# Usage: ./lightning-check.sh <paymentHash> [id]
+# Returns: {"paid": true|false, ...}
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-check "$@"

--- a/archon-lightning/scripts/lightning/lightning-decode.sh
+++ b/archon-lightning/scripts/lightning/lightning-decode.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-decode.sh - Decode BOLT11 invoice details
+# Usage: ./lightning-decode.sh <bolt11>
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-decode "$@"

--- a/archon-lightning/scripts/lightning/lightning-decode.sh
+++ b/archon-lightning/scripts/lightning/lightning-decode.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # lightning-decode.sh - Decode BOLT11 invoice details
 # Usage: ./lightning-decode.sh <bolt11>
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster lightning-decode "$@"

--- a/archon-lightning/scripts/lightning/lightning-invoice.sh
+++ b/archon-lightning/scripts/lightning/lightning-invoice.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-invoice.sh - Create BOLT11 invoice to receive sats
+# Usage: ./lightning-invoice.sh <amount> <memo> [id]
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-invoice "$@"

--- a/archon-lightning/scripts/lightning/lightning-invoice.sh
+++ b/archon-lightning/scripts/lightning/lightning-invoice.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # lightning-invoice.sh - Create BOLT11 invoice to receive sats
 # Usage: ./lightning-invoice.sh <amount> <memo> [id]
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster lightning-invoice "$@"

--- a/archon-lightning/scripts/lightning/lightning-pay.sh
+++ b/archon-lightning/scripts/lightning/lightning-pay.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# lightning-pay.sh - Pay BOLT11 invoice
+# lightning-pay.sh - Pay BOLT11 invoice with automatic verification
 # Usage: ./lightning-pay.sh <bolt11> [id]
-# Returns: {"paymentHash": "..."} - ALWAYS VERIFY WITH lightning-check.sh!
+# Returns: {"paymentHash": "...", "paid": true/false, "preimage": "..."}
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
-npx @didcid/keymaster lightning-pay "$@"
+# Pay the invoice
+result=$(npx @didcid/keymaster lightning-pay "$@")
+hash=$(echo "$result" | jq -r .paymentHash)
+
+# Verify payment settled
+npx @didcid/keymaster lightning-check "$hash" "${2:-}"

--- a/archon-lightning/scripts/lightning/lightning-pay.sh
+++ b/archon-lightning/scripts/lightning/lightning-pay.sh
@@ -11,5 +11,5 @@ source ~/.archon.env
 result=$(npx @didcid/keymaster lightning-pay "$@")
 hash=$(echo "$result" | jq -r .paymentHash)
 
-# Verify payment settled
+# Verify payment settled and return combined result
 npx @didcid/keymaster lightning-check "$hash" "${2:-}"

--- a/archon-lightning/scripts/lightning/lightning-pay.sh
+++ b/archon-lightning/scripts/lightning/lightning-pay.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-pay.sh - Pay BOLT11 invoice
+# Usage: ./lightning-pay.sh <bolt11> [id]
+# Returns: {"paymentHash": "..."} - ALWAYS VERIFY WITH lightning-check.sh!
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-pay "$@"

--- a/archon-lightning/scripts/lightning/lightning-pay.sh
+++ b/archon-lightning/scripts/lightning/lightning-pay.sh
@@ -11,5 +11,12 @@ source ~/.archon.env
 result=$(npx @didcid/keymaster lightning-pay "$@")
 hash=$(echo "$result" | jq -r .paymentHash)
 
-# Verify payment settled and return combined result
-npx @didcid/keymaster lightning-check "$hash" "${2:-}"
+# Verify payment settled
+status=$(npx @didcid/keymaster lightning-check "$hash" "${2:-}" | jq -r .paid)
+
+if [ "$status" = "true" ]; then
+  echo "✅ Payment confirmed"
+else
+  echo "❌ Payment failed or pending"
+  exit 1
+fi

--- a/archon-lightning/scripts/lightning/lightning-payments.sh
+++ b/archon-lightning/scripts/lightning/lightning-payments.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-payments.sh - Show payment history
+# Usage: ./lightning-payments.sh [id]
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-payments "$@"

--- a/archon-lightning/scripts/lightning/lightning-payments.sh
+++ b/archon-lightning/scripts/lightning/lightning-payments.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # lightning-payments.sh - Show payment history
 # Usage: ./lightning-payments.sh [id]
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster lightning-payments "$@"

--- a/archon-lightning/scripts/lightning/lightning-zap.sh
+++ b/archon-lightning/scripts/lightning/lightning-zap.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 # Usage: ./lightning-zap.sh <recipient> <amount> [memo] [id]
 # recipient: Lightning Address (user@domain.com), DID, or alias
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster lightning-zap "$@"

--- a/archon-lightning/scripts/lightning/lightning-zap.sh
+++ b/archon-lightning/scripts/lightning/lightning-zap.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lightning-zap.sh - Send sats via Lightning Address, DID, or alias
+# Usage: ./lightning-zap.sh <recipient> <amount> [memo] [id]
+# recipient: Lightning Address (user@domain.com), DID, or alias
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster lightning-zap "$@"

--- a/archon-lightning/scripts/lightning/lightning-zap.sh
+++ b/archon-lightning/scripts/lightning/lightning-zap.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# lightning-zap.sh - Send sats via Lightning Address, DID, or alias
+# lightning-zap.sh - Send sats via Lightning Address, DID, or alias with automatic verification
 # Usage: ./lightning-zap.sh <recipient> <amount> [memo] [id]
 # recipient: Lightning Address (user@domain.com), DID, or alias
 
 source ~/.archon.env
 
-npx @didcid/keymaster lightning-zap "$@"
+# Send the zap
+result=$(npx @didcid/keymaster lightning-zap "$@")
+hash=$(echo "$result" | jq -r .paymentHash)
+
+# Verify payment settled
+status=$(npx @didcid/keymaster lightning-check "$hash" "${4:-}" | jq -r .paid)
+
+if [ "$status" = "true" ]; then
+  echo "✅ Payment confirmed"
+else
+  echo "❌ Payment failed or pending"
+  exit 1
+fi

--- a/archon-lightning/scripts/lightning/publish-lightning.sh
+++ b/archon-lightning/scripts/lightning/publish-lightning.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # publish-lightning.sh - Publish Lightning endpoint to DID document
 # Usage: ./publish-lightning.sh [id]
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster publish-lightning "$@"

--- a/archon-lightning/scripts/lightning/publish-lightning.sh
+++ b/archon-lightning/scripts/lightning/publish-lightning.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# publish-lightning.sh - Publish Lightning endpoint to DID document
+# Usage: ./publish-lightning.sh [id]
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster publish-lightning "$@"

--- a/archon-lightning/scripts/lightning/unpublish-lightning.sh
+++ b/archon-lightning/scripts/lightning/unpublish-lightning.sh
@@ -1,0 +1,10 @@
+#!/usr/*bin/env bash
+set -euo pipefail
+
+# unpublish-lightning.sh - Remove Lightning endpoint from DID document
+# Usage: ./unpublish-lightning.sh [id]
+
+source ~/.nvm/nvm.sh
+source ~/.archon.env
+
+npx @didcid/keymaster unpublish-lightning "$@"

--- a/archon-lightning/scripts/lightning/unpublish-lightning.sh
+++ b/archon-lightning/scripts/lightning/unpublish-lightning.sh
@@ -1,4 +1,4 @@
-#!/usr/*bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # unpublish-lightning.sh - Remove Lightning endpoint from DID document

--- a/archon-lightning/scripts/lightning/unpublish-lightning.sh
+++ b/archon-lightning/scripts/lightning/unpublish-lightning.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # unpublish-lightning.sh - Remove Lightning endpoint from DID document
 # Usage: ./unpublish-lightning.sh [id]
 
-source ~/.nvm/nvm.sh
 source ~/.archon.env
 
 npx @didcid/keymaster unpublish-lightning "$@"


### PR DESCRIPTION
# Add archon-lightning skill

Adds Lightning Network payment support to Archon agent skills.

## What This Adds

- Lightning wallet creation and management
- Invoice generation and payment
- Lightning Address zapping
- Payment verification patterns
- Balance checking and history
- DID document integration

## Structure

- `README.md` — Marketing overview with examples and comparisons
- `SKILL.md` — Complete praxis documentation with YAML frontmatter
- `scripts/lightning/` — Bash wrappers for all Lightning commands (10 scripts)

## Key Features

### Payment Verification Pattern
Critical security pattern documented prominently: always verify payments with `lightning-check` after `lightning-pay`. Payment hash ≠ success.

### DID Integration
Publish Lightning endpoints to DID documents for discoverability.

### Lightning Address Support
Send to `user@domain.com` Lightning Addresses, DIDs, or aliases.

## Testing

Verified locally:
- All scripts are executable
- Scripts source environment correctly (nvm, archon.env)
- Keymaster CLI has all documented Lightning commands
- Follows patterns from archon-keymaster and archon-vault

## Documentation

- Comprehensive README.md explaining "why this matters" for AI agents
- Complete SKILL.md with usage examples, workflows, error handling
- Payment verification pattern explained with correct/incorrect examples
- Security best practices and troubleshooting

## Patterns Followed

- Structure matches archon-keymaster and archon-vault
- YAML frontmatter with proper openclaw metadata
- Scripts wrap keymaster commands with env setup
- Executable permissions set correctly